### PR TITLE
Do Linux compatibility

### DIFF
--- a/ctOS_Registration/Form2.cs
+++ b/ctOS_Registration/Form2.cs
@@ -111,7 +111,13 @@ namespace ctOS_Registration {
 
             try {
                 if (!fileError) {
-                    System.Diagnostics.Process.Start(@"c:\Windows\notepad.exe", filename);
+                    int p = (int) Environment.OSVersion.Platform;
+                    if((p == 4) || (p == 6) || (p == 128)) { // Running on Unix
+                        System.Diagnostics.Process.Start("xdg-open", filename)
+                    } else { // Running on not Unix
+                        System.Diagnostics.Process.Start(@"c:\Windows\notepad.exe", filename);
+                    }
+                }
                 }
             } catch (Exception ex) {
                 MessageBox.Show(ex.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);


### PR DESCRIPTION
Note that, in theory, compiling two separate exe files is not required; as (newer versions of) mono can run the bytecode just fine.